### PR TITLE
wpan-ping fix to not enter daemon mode in all cases

### DIFF
--- a/package/network/utils/wpan-tools/Makefile
+++ b/package/network/utils/wpan-tools/Makefile
@@ -8,11 +8,11 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=wpan-tools
-PKG_VERSION:=0.5
+PKG_VERSION:=0.6
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.bz2
 PKG_SOURCE_URL:=http://wpan.cakelab.org/releases/
-PKG_MD5SUM:=6226df405a98c13ec41bf4d1f0777d6b
+PKG_MD5SUM:=dd5367fe36ad8269263a29edad073bf7
 
 include $(INCLUDE_DIR)/package.mk
 

--- a/package/network/utils/wpan-tools/patches/0001-wpan-ping-ensure-the-memory-for-our-config-struct-is.patch
+++ b/package/network/utils/wpan-tools/patches/0001-wpan-ping-ensure-the-memory-for-our-config-struct-is.patch
@@ -1,0 +1,33 @@
+From e93f6e23b7035d6a76ca9988fdfb5c46dd06cd0f Mon Sep 17 00:00:00 2001
+From: Stefan Schmidt <stefan@datenfreihafen.org>
+Date: Sat, 16 Apr 2016 23:50:46 +0200
+Subject: [PATCH 1/2] wpan-ping: ensure the memory for our config struct is
+ initialized.
+
+This came up on one embedded system which went into daemon mode no
+matter what options given on the commandline. Turns out we never made
+sure our config struct is actually set to zeor and thus the server
+mode flag had random values. Make sure we have a clean start by using
+calloc.
+
+Signed-off-by: Stefan Schmidt <stefan@datenfreihafen.org>
+---
+ wpan-ping/wpan-ping.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/wpan-ping/wpan-ping.c b/wpan-ping/wpan-ping.c
+index 92f4cf8..cbad1fc 100644
+--- a/wpan-ping/wpan-ping.c
++++ b/wpan-ping/wpan-ping.c
+@@ -438,7 +438,7 @@ int main(int argc, char *argv[]) {
+ 	struct config *conf;
+ 	char *dst_addr = NULL;
+ 
+-	conf = malloc(sizeof(struct config));
++	conf = calloc(1, sizeof(struct config));
+ 
+ 	/* Default to interface wpan0 if nothing else is given */
+ 	conf->interface = "wpan0";
+-- 
+2.5.5
+

--- a/package/network/utils/wpan-tools/patches/0002-wpan-ping-set-more-default-values-for-our-configurat.patch
+++ b/package/network/utils/wpan-tools/patches/0002-wpan-ping-set-more-default-values-for-our-configurat.patch
@@ -1,0 +1,52 @@
+From ba1a7cc8073d8d9c467973f5d63b15f74a606247 Mon Sep 17 00:00:00 2001
+From: Stefan Schmidt <stefan@datenfreihafen.org>
+Date: Sat, 16 Apr 2016 23:55:49 +0200
+Subject: [PATCH 2/2] wpan-ping: set more default values for our configuration
+
+Make sure we actually have sane default values for the internal
+configuration. This also fixes a side effect from the calloc fix.
+The packet counter was zero from now on but we actually want the
+highest number when no other value is given on the commandline.
+
+Also fix a typo while being there.
+
+Signed-off-by: Stefan Schmidt <stefan@datenfreihafen.org>
+---
+ wpan-ping/wpan-ping.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/wpan-ping/wpan-ping.c b/wpan-ping/wpan-ping.c
+index cbad1fc..603536e 100644
+--- a/wpan-ping/wpan-ping.c
++++ b/wpan-ping/wpan-ping.c
+@@ -32,6 +32,7 @@
+ #include <unistd.h>
+ #include <getopt.h>
+ #include <stdbool.h>
++#include <limits.h>
+ 
+ #include <netlink/netlink.h>
+ 
+@@ -443,12 +444,18 @@ int main(int argc, char *argv[]) {
+ 	/* Default to interface wpan0 if nothing else is given */
+ 	conf->interface = "wpan0";
+ 
+-	/* Deafult to minimum packet size */
++	/* Default to minimum packet size */
+ 	conf->packet_len = MIN_PAYLOAD_LEN;
+ 
+ 	/* Default to short addressing */
+ 	conf->extended = false;
+ 
++	/* Default to client mode */
++	conf->server = false;
++
++	/* Default to 65535 packets being sent */
++	conf->packets = USHRT_MAX;
++
+ 	if (argc < 2) {
+ 		usage(argv[0]);
+ 		exit(1);
+-- 
+2.5.5
+


### PR DESCRIPTION
This turned out to be a upstream problem after all. Thanks for spotting it!

With this two patches it is working as expected on my Ci40. Once there is a new wpan-tools releasde and we update here they can be dropped.