### PR TITLE
Revert "Adding sqlite3 download link to openwrt's default download mirrors"

### DIFF
--- a/scripts/download.pl
+++ b/scripts/download.pl
@@ -197,7 +197,6 @@ foreach my $mirror (@ARGV) {
 #push @mirrors, 'http://mirror1.openwrt.org';
 push @mirrors, 'http://mirror2.openwrt.org/sources';
 push @mirrors, 'http://downloads.openwrt.org/sources';
-push @mirrors, 'http://ftp.osuosl.org/pub/blfs/conglomeration/sqlite';
 
 while (!$ok) {
 	my $mirror = shift @mirrors;


### PR DESCRIPTION
This reverts commit 49025c87ed09a080b982d56d667676a2b4241e50.