### PR TITLE
usleep: enable by default in busybox configuration file

### DIFF
--- a/package/utils/busybox/Config-defaults.in
+++ b/package/utils/busybox/Config-defaults.in
@@ -783,7 +783,7 @@ config BUSYBOX_DEFAULT_UNIQ
 	default y
 config BUSYBOX_DEFAULT_USLEEP
 	bool
-	default n
+	default y
 config BUSYBOX_DEFAULT_UUDECODE
 	bool
 	default n


### PR DESCRIPTION
Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>