### PR TITLE
Remove i2s_dac_clk handle from pistachio_audio_card device tree defin…

### DIFF
--- a/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
+++ b/target/linux/pistachio/dts/pistachio_marduk_ca8210.dts
@@ -52,7 +52,7 @@
 			img,event-timer = <&event_timer>;
 
 			pinctrl-names = "default";
-			pinctrl-0 = <&dac_clk_pin>, <&i2s_mclk_pin>;
+			pinctrl-0 = <&i2s_mclk_pin>;
 
 			spdif-out {
 				cpu-dai = <&spdif_out>;

--- a/target/linux/pistachio/dts/pistachio_marduk_cc2520.dts
+++ b/target/linux/pistachio/dts/pistachio_marduk_cc2520.dts
@@ -52,7 +52,7 @@
 			img,event-timer = <&event_timer>;
 
 			pinctrl-names = "default";
-			pinctrl-0 = <&dac_clk_pin>, <&i2s_mclk_pin>;
+			pinctrl-0 = <&i2s_mclk_pin>;
 
 			spdif-out {
 				cpu-dai = <&spdif_out>;


### PR DESCRIPTION
…ition

If the pistachio audio card has the handle to the i2s_dac_clk (which is
tied to switch 1 on Ci-40), then no events are triggered when switch 1 is
pressed.

Signed-off-by: Francois Berder <Francois.Berder@imgtec.com>