### PR TITLE
marduk: simplify the marduk profiles and allow custom device tree

### DIFF
--- a/target/linux/pistachio/image/Makefile
+++ b/target/linux/pistachio/image/Makefile
@@ -74,7 +74,7 @@ endif
 endef
 
 define Image/Build
-	$(call Image/Build/Profile/$(PROFILE),$(1))
+	$(call Image/BuildNAND/$(1),$(1),$(PROFILE))
 endef
 
 define Image/BuildKernel/uImage
@@ -87,7 +87,7 @@ endif
 endef
 
 define Image/BuildKernel
-	$(call MkDTB,pistachio_$(DEVICE_DTS))
+	$(call MkDTB,$($(PROFILE)_DEVICE_DTS))
 	$(call Image/BuildKernel/uImage,$(PROFILE))
 endef
 
@@ -107,8 +107,8 @@ define Image/InstallKernel/copy
 	$(INSTALL_DIR) $(TARGET_DIR)/boot
 
 ifneq ($(1),)
-	$(CP) $(KDIR)/pistachio_$(DEVICE_DTS).dtb $(TARGET_DIR)/boot/
-	ln -sf boot/pistachio_$(DEVICE_DTS).dtb $(TARGET_DIR)/pistachio_$(BOARDNAME).dtb
+	$(CP) $(KDIR)/$($(PROFILE)_DEVICE_DTS).dtb $(TARGET_DIR)/boot/
+	ln -sf boot/$($(PROFILE)_DEVICE_DTS).dtb $(TARGET_DIR)/pistachio_$(BOARDNAME).dtb
 endif
 #endif
 

--- a/target/linux/pistachio/marduk/profiles/marduk_ca8210.mk
+++ b/target/linux/pistachio/marduk/profiles/marduk_ca8210.mk
@@ -24,12 +24,8 @@
 #
 
 define Profile/marduk_ca8210
-    NAME:=Basic platform profile for Marduk with Cascoda ca8210
-    PACKAGES:=kmod-i2c kmod-cascoda kmod-sound-pistachio-soc \
-              wpan-tools tcpdump uhttpd uboot-envtools \
-              alsa-lib alsa-utils alsa-utils-tests i2c-tools \
-              iw hostapd wpa-supplicant kmod-uccp420wlan kmod-cfg80211
-    DEVICE_DTS:=marduk_ca8210
+	NAME:=Basic platform profile for Marduk with Cascoda ca8210
+	PACKAGES:=kmod-cascoda wpan-tools
 endef
 
 define Profile/marduk_ca8210/Description
@@ -37,9 +33,4 @@ define Profile/marduk_ca8210/Description
         board
 endef
 
-marduk_ca8210_UBIFS_OPTS:="-m 4096 -e 253952 -c 1580"
-marduk_ca8210_UBI_OPTS:="-m 4096 -p 262144 -s 4096"
-
-Image/Build/Profile/marduk_ca8210=$(call Image/BuildNAND/$(1),$(1),marduk_ca8210)
-
-$(eval $(call Profile,marduk_ca8210))
+$(eval $(call Profile/marduk/default,marduk_ca8210,pistachio_marduk_ca8210))

--- a/target/linux/pistachio/marduk/profiles/marduk_cc2520.mk
+++ b/target/linux/pistachio/marduk/profiles/marduk_cc2520.mk
@@ -24,12 +24,8 @@
 #
 
 define Profile/marduk_cc2520
-    NAME:=Basic platform profile for Marduk with TI cc2520
-    PACKAGES:=kmod-i2c kmod-marduk-cc2520 kmod-sound-pistachio-soc \
-		wpan-tools tcpdump uhttpd uboot-envtools \
-		alsa-lib alsa-utils alsa-utils-tests i2c-tools \
-		iw hostapd wpa-supplicant kmod-uccp420wlan kmod-cfg80211
-    DEVICE_DTS:=marduk_cc2520
+	NAME:=Basic platform profile for Marduk with TI cc2520
+	PACKAGES:=kmod-marduk-cc2520 wpan-tools
 endef
 
 define Profile/marduk_cc2520/Description
@@ -37,9 +33,5 @@ define Profile/marduk_cc2520/Description
         board
 endef
 
-marduk_cc2520_UBIFS_OPTS:="-m 4096 -e 253952 -c 1580"
-marduk_cc2520_UBI_OPTS:="-m 4096 -p 262144 -s 4096"
 
-Image/Build/Profile/marduk_cc2520=$(call Image/BuildNAND/$(1),$(1),marduk_cc2520)
-
-$(eval $(call Profile,marduk_cc2520))
+$(eval $(call Profile/marduk/default,marduk_cc2520,pistachio_marduk_cc2520))

--- a/target/linux/pistachio/marduk/profiles/marduk_cc2520_wifi.mk
+++ b/target/linux/pistachio/marduk/profiles/marduk_cc2520_wifi.mk
@@ -25,7 +25,7 @@
 
 define Profile/marduk_cc2520_wifi
     NAME:=Wifi testing profile for Marduk with TI cc2520
-    PACKAGES:=wpa-cli iperf fping
+    PACKAGES:=kmod-marduk-cc2520 wpan-tools wpa-cli iperf fping
 endef
 
 define Profile/marduk_cc2520_wifi/Description

--- a/target/linux/pistachio/marduk/profiles/marduk_cc2520_wifi.mk
+++ b/target/linux/pistachio/marduk/profiles/marduk_cc2520_wifi.mk
@@ -25,12 +25,7 @@
 
 define Profile/marduk_cc2520_wifi
     NAME:=Wifi testing profile for Marduk with TI cc2520
-    PACKAGES:=kmod-i2c kmod-marduk-cc2520 kmod-sound-pistachio-soc \
-        wpan-tools tcpdump uhttpd uboot-envtools \
-        alsa-lib alsa-utils alsa-utils-tests i2c-tools \
-        iw hostapd wpa-supplicant wpa-cli iperf fping \
-        kmod-uccp420wlan kmod-cfg80211
-    DEVICE_DTS:=marduk_cc2520
+    PACKAGES:=wpa-cli iperf fping
 endef
 
 define Profile/marduk_cc2520_wifi/Description
@@ -38,9 +33,4 @@ define Profile/marduk_cc2520_wifi/Description
         board
 endef
 
-marduk_cc2520_wifi_UBIFS_OPTS:="-m 4096 -e 253952 -c 1580"
-marduk_cc2520_wifi_UBI_OPTS:="-m 4096 -p 262144 -s 4096"
-
-Image/Build/Profile/marduk_cc2520_wifi=$(call Image/BuildNAND/$(1),$(1),marduk_cc2520_wifi)
-
-$(eval $(call Profile,marduk_cc2520_wifi))
+$(eval $(call Profile/marduk/default,marduk_cc2520_wifi,pistachio_marduk_cc2520))

--- a/target/linux/pistachio/marduk/target.mk
+++ b/target/linux/pistachio/marduk/target.mk
@@ -25,6 +25,27 @@
 
 BOARDNAME:=marduk
 
+DEFAULT_PACKAGES+=kmod-i2c i2c-tools \
+                  kmod-sound-pistachio-soc alsa-lib alsa-utils alsa-utils-test \
+                  kmod-uccp420wlan kmod-cfg80211 iw hostapd wpa-supplicant \
+                  uboot-envtools tcpdump
+
+define Profile/marduk/default
+	$(1)_DEVICE_DTS:=$(2)
+ifeq ($(3),)
+        $(1)_UBIFS_OPTS:="-m 4096 -e 253952 -c 1580"
+else
+	$(1)_UBIFS_OPTS:=$(3)
+endif
+ifeq ($(4),)
+        $(1)_UBI_OPTS:="-m 4096 -p 262144 -s 4096"
+else
+	$(1)_UBI_OPTS:=$(4)
+endif
+	$(eval $(call Profile,$(1)))
+endef
+
+
 define Target/Description
         Marduk
 endef


### PR DESCRIPTION
Marduk profiles are now very simple:

```
define Profile/marduk_profile_name
    NAME:=Profile Name
    PACKAGES:=<extra packages>
endef

define Profile/marduk_profile_name/Description
    Profile description
endef

$(eval $(call Profile/marduk/default,marduk_profile_name,<device tree prefix>))
```

```<extra packages>``` are any packages on top of the default set of packages.
```<device tree prefix>``` is the file name of the device tree (before .dts).

The change shown below allows for a new device tree parameter to specify the device tree when creating a profile.
```
-$(eval $(call Profile,marduk_profile_name))
+$(eval $(call Profile/marduk/default,marduk_profile_name,<device tree prefix>))
```